### PR TITLE
webhook送信データの変更に伴う修正

### DIFF
--- a/index.php
+++ b/index.php
@@ -49,7 +49,7 @@ if ($_SERVER['HTTP_X_FORWARDED_PROTO'] != 'https') {
   <hr>
   <footer>
     <div class="row">
-      <a href="https://github.com/metaps/spike-checkout-demo" target="_blank">spike-checkout-demo</a> version:1.1.0
+      <a href="https://github.com/metaps/spike-checkout-demo" target="_blank">spike-checkout-demo</a> version:1.2.0
     </div>
   </footer>
 

--- a/webhook_endpoint.php
+++ b/webhook_endpoint.php
@@ -46,12 +46,12 @@ if (empty($data['secret_key'])) {
 }
 
 
-$json = urldecode(file_get_contents('php://input'));
+$json = file_get_contents('php://input');
 
 
 
 // signature check
-$signature = base64_encode(hash_hmac('sha256', json_decode($json), $data['secret_key'], true));
+$signature = base64_encode(hash_hmac('sha256', $json, $data['secret_key'], true));
 
 $data['body'] = $json;
 $data['server'] = serialize($_SERVER);


### PR DESCRIPTION
2015-03-31
SPIKE の Webhook が `urlencode` と `json_encode` を取り除く対応を実施しました。
https://spike.cc/dashboard/developer/docs/references#a4

そのため不要な `urldecode` と `json_decode` を削除します。
